### PR TITLE
Fix optimization remarks for HCC

### DIFF
--- a/hc/src/hc_kernel.cl
+++ b/hc/src/hc_kernel.cl
@@ -2,6 +2,7 @@
 #include "irif.h"
 
 #define ATTR __attribute__((always_inline, const))
+#define ATTR2 __attribute__((always_inline))
 
 ATTR long
 amp_get_global_id(int dim)
@@ -75,14 +76,16 @@ hc_get_group_size(int dim)
   return __ockl_get_local_size(dim);
 }
 
-void hc_barrier(int n)
+ATTR2 void
+hc_barrier(int n)
 {
   __llvm_amdgcn_s_waitcnt(0);
   __llvm_amdgcn_s_dcache_wb();
   __llvm_amdgcn_s_barrier();
 }
 
-void amp_barrier(int n)
+ATTR2 void
+amp_barrier(int n)
 {
   hc_barrier(n);
 }

--- a/hc/src/hc_kernel.cl
+++ b/hc/src/hc_kernel.cl
@@ -1,62 +1,76 @@
 #include "ockl.h"
 #include "irif.h"
 
-long amp_get_global_id(int dim)
+#define ATTR __attribute__((always_inline, const))
+
+ATTR long
+amp_get_global_id(int dim)
 {
   return __ockl_get_global_id(dim);
 }
 
-long amp_get_global_size(int dim)
+ATTR long
+amp_get_global_size(int dim)
 {
   return __ockl_get_global_size(dim);
 }
 
-long amp_get_local_id(int dim)
+ATTR long
+amp_get_local_id(int dim)
 {
   return __ockl_get_local_id(dim);
 }
 
-long amp_get_num_groups(int dim)
+ATTR long
+amp_get_num_groups(int dim)
 {
   return __ockl_get_num_groups(dim);
 }
 
-long amp_get_group_id(int dim)
+ATTR long
+amp_get_group_id(int dim)
 {
   return __ockl_get_group_id(dim);
 }
 
-long amp_get_local_size(int dim)
+ATTR long
+amp_get_local_size(int dim)
 {
   return __ockl_get_local_size(dim);
 }
 
-long hc_get_grid_size(int dim)
+ATTR long
+hc_get_grid_size(int dim)
 {
   return __ockl_get_global_size(dim);
 }
 
-long hc_get_workitem_absolute_id(int dim)
+ATTR long
+hc_get_workitem_absolute_id(int dim)
 {
   return __ockl_get_global_id(dim);
 }
 
-long hc_get_workitem_id(int dim)
+ATTR long
+hc_get_workitem_id(int dim)
 {
   return __ockl_get_local_id(dim);
 }
 
-long hc_get_num_groups(int dim)
+ATTR long
+hc_get_num_groups(int dim)
 {
   return __ockl_get_num_groups(dim);
 }
 
-long hc_get_group_id(int dim)
+ATTR long
+hc_get_group_id(int dim)
 {
   return __ockl_get_group_id(dim);
 }
 
-long hc_get_group_size(int dim)
+ATTR long
+hc_get_group_size(int dim)
 {
   return __ockl_get_local_size(dim);
 }


### PR DESCRIPTION
Mark workitem & barrier related functions with "always_inline" attribute so HCC won't raise optimization remarks in LLC.

Following functions are changed:

- workitem
- barrier

Following ones are not changed yet and may be amended later or come in a separate pull request:

- math
- atomic