### PR TITLE
Add a function to simulate CUDA smid

### DIFF
--- a/cuda2gcn/src/smid.cl
+++ b/cuda2gcn/src/smid.cl
@@ -1,0 +1,21 @@
+/*===--------------------------------------------------------------------------
+ *                   ROCm Device Libraries
+ *
+ * This file is distributed under the University of Illinois Open Source
+ * License. See LICENSE.TXT for details.
+ *===------------------------------------------------------------------------*/
+
+#include "irif.h"
+
+#define ATTR __attribute__((always_inline, const))
+
+#define REGISTER   4
+#define MASK      15
+
+// cu id in amdgcn
+
+ATTR int __smid()
+{
+    return __llvm_amdgcn_s_getreg(REGISTER) >> 8 & MASK;
+}
+


### PR DESCRIPTION
use __ score prefix, so we don't mix with user name space.