### PR TITLE
Replace double precision literals with single precision in *F.cl

### DIFF
--- a/ocml/src/asinhF.cl
+++ b/ocml/src/asinhF.cl
@@ -20,7 +20,7 @@ MATH_MANGLE(asinh)(float x)
     float s = b ? 0x1.0p-64f : 1.0f;
     float sy = y * s;
     float2 a = add(sy, root2(add(sqr(sy), s*s)));
-    float z = MATH_PRIVATE(lnep)(a) + (b ? 0x1.62e430p+5f : 0.0);
+    float z = MATH_PRIVATE(lnep)(a) + (b ? 0x1.62e430p+5f : 0.0f);
     z = y < 0x1.0p-12f ? y : z;
 
     if (!FINITE_ONLY_OPT()) {
@@ -29,4 +29,3 @@ MATH_MANGLE(asinh)(float x)
 
     return BUILTIN_COPYSIGN_F32(z, x);
 }
-

--- a/ocml/src/erfF.cl
+++ b/ocml/src/erfF.cl
@@ -28,13 +28,13 @@ MATH_MANGLE(erf)(float x)
                   -0x1.a90f70p-2f), 0x1.a91224p-2f), 0x1.af767ap-1f);
 
     } else if (ax < 2.5f) {
-        float t = ax - 1.75;
+        float t = ax - 1.75f;
         ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
               MATH_MAD(t, MATH_MAD(t,
                   -0x1.6c7276p-10f, 0x1.f0807ep-7f), -0x1.a90488p-5f), 0x1.74f388p-4f),
                   -0x1.7ab6aap-4f), 0x1.b05ea0p-5f), 0x1.f92d06p-1f);
     } else if (ax < 3.9375f) {
-        float t = ax - 2.5;
+        float t = ax - 2.5f;
         ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
               MATH_MAD(t, MATH_MAD(t,
                   0x1.b94482p-16f, -0x1.9d0710p-13f), -0x1.b43cb6p-12f), 0x1.01db88p-7f),
@@ -50,4 +50,3 @@ MATH_MANGLE(erf)(float x)
     ret = BUILTIN_COPYSIGN_F32(ret, x);
     return ret;
 }
-

--- a/ocml/src/erfcinvF.cl
+++ b/ocml/src/erfcinvF.cl
@@ -15,10 +15,10 @@ MATH_MANGLE(erfcinv)(float y)
     if (y > 0.625f) {
         ret = MATH_MANGLE(erfinv)(1.0f - y);
     } else if (y > 0x1.0p-10f) {
-        float t = -MATH_MANGLE(log)(y * (2.0 - y)) - 3.125f;
-        ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, 
-              MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, 
-              MATH_MAD(t, MATH_MAD(t, 
+        float t = -MATH_MANGLE(log)(y * (2.0f - y)) - 3.125f;
+        ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
+              MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
+              MATH_MAD(t, MATH_MAD(t,
                   0x1.7ee662p-31f, -0x1.3f5a80p-28f), -0x1.b638f0p-26f), 0x1.c9ccc6p-22f),
                   -0x1.72f8aep-20f), -0x1.d21aa6p-17f), 0x1.87aebcp-13f), -0x1.8455d4p-11f),
                   -0x1.8b6ca4p-8f), 0x1.ebd80cp-3f), 0x1.a755e8p+0f);
@@ -28,13 +28,13 @@ MATH_MANGLE(erfcinv)(float y)
         float t = MATH_FAST_RCP(s);
 
         if (y > 0x1.0p-42f) {
-            ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, 
-                  MATH_MAD(t, MATH_MAD(t, 
+            ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
+                  MATH_MAD(t, MATH_MAD(t,
                       -0x1.57221ep+0f, 0x1.7f6144p+1f), -0x1.98dd40p+1f), 0x1.2c9066p+1f),
                       -0x1.3a07eap+0f), -0x1.ba546cp-5f), 0x1.004e66p+0f);
         } else {
-            ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, 
-                  MATH_MAD(t, MATH_MAD(t, 
+            ret = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
+                  MATH_MAD(t, MATH_MAD(t,
                       -0x1.649c6ap+4f, 0x1.8fa8fap+4f), -0x1.a112d8p+3f), 0x1.309d98p+2f),
                       -0x1.919488p+0f), -0x1.c084ecp-6f), 0x1.00143ep+0f);
         }
@@ -49,4 +49,3 @@ MATH_MANGLE(erfcinv)(float y)
 
     return ret;
 }
-

--- a/ocml/src/erfinvF.cl
+++ b/ocml/src/erfinvF.cl
@@ -15,8 +15,8 @@ MATH_MANGLE(erfinv)(float x)
 
     if (ax < 0.375f) {
         float t = ax*ax;
-        p = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, 
-            MATH_MAD(t, MATH_MAD(t, 
+        p = MATH_MAD(t, MATH_MAD(t, MATH_MAD(t, MATH_MAD(t,
+            MATH_MAD(t, MATH_MAD(t,
                 0x1.48b6cap-3f, -0x1.a2930ap-6f), 0x1.65b0b4p-4f), 0x1.5581aep-4f),
                 0x1.05aa56p-3f), 0x1.db2748p-3f), 0x1.c5bf8ap-1f);
     } else {
@@ -48,10 +48,9 @@ MATH_MANGLE(erfinv)(float x)
     float ret = p*ax;
 
     if (!FINITE_ONLY_OPT()) {
-        ret = ax > 1.0 ? AS_FLOAT(QNANBITPATT_SP32) : ret;
-        ret = ax == 1.0 ? AS_FLOAT(PINFBITPATT_SP32) : ret;
+        ret = ax > 1.0f ? AS_FLOAT(QNANBITPATT_SP32) : ret;
+        ret = ax == 1.0f ? AS_FLOAT(PINFBITPATT_SP32) : ret;
     }
 
     return BUILTIN_COPYSIGN_F32(ret, x);
 }
-

--- a/ocml/src/expepF.cl
+++ b/ocml/src/expepF.cl
@@ -17,12 +17,12 @@ MATH_PRIVATE(expep)(float2 x)
     float2 t = fsub(fsub(sub(x, fn*0x1.62e400p-1f), fn*0x1.7f7800p-20f), fn*0x1.473de6p-34f);
 
     float th = t.hi;
-    float p = MATH_MAD(th, MATH_MAD(th, MATH_MAD(th, MATH_MAD(th, 
+    float p = MATH_MAD(th, MATH_MAD(th, MATH_MAD(th, MATH_MAD(th,
                   0x1.6850e4p-10f, 0x1.123bccp-7f), 0x1.555b98p-5f), 0x1.55548ep-3f),
                   0x1.fffff8p-2f);
 
     float2 r = fadd(t, mul(sqr(t), p));
-    float z = 1.0 + r.hi;
+    float z = 1.0f + r.hi;
 
     z = BUILTIN_FLDEXP_F32(z, (int)fn);
 
@@ -31,4 +31,3 @@ MATH_PRIVATE(expep)(float2 x)
 
     return z;
 }
-

--- a/ocml/src/lgamma_rF.cl
+++ b/ocml/src/lgamma_rF.cl
@@ -172,7 +172,7 @@ MATH_MANGLE(lgamma_r_impl)(float x)
     if (ax < 0x1.0p-6f) {
         ret = MATH_MAD(ax, MATH_MAD(ax, MATH_MAD(ax, MATH_MAD(ax, z4, z3), z2), z1),
                        -MATH_MANGLE(log)(ax));
-    } else if (ax < 2.0) {
+    } else if (ax < 2.0f) {
         int i;
         bool c;
         float y, t;

--- a/ocml/src/log1pF.cl
+++ b/ocml/src/log1pF.cl
@@ -15,7 +15,7 @@ extern CONSTATTR float MATH_PRIVATE(lnep)(float2 x);
 CONSTATTR float
 MATH_MANGLE(log1p)(float x)
 {
-    float z = MATH_PRIVATE(lnep)(add(1.0, x));
+    float z = MATH_PRIVATE(lnep)(add(1.0f, x));
 
     if (!FINITE_ONLY_OPT()) {
         z = BUILTIN_CLASS_F32(x, CLASS_PINF) ? x : z;
@@ -25,4 +25,3 @@ MATH_MANGLE(log1p)(float x)
 
     return BUILTIN_ABS_F32(x) < 0x1.0p-24f ? x : z;
 }
-

--- a/ocml/src/rsqrtF.cl
+++ b/ocml/src/rsqrtF.cl
@@ -14,7 +14,6 @@ MATH_MANGLE(rsqrt)(float x)
         return BUILTIN_RSQRT_F32(x);
     } else {
         bool s = x < 0x1.0p-100f;
-        return BUILTIN_RSQRT_F32(x * (s ? 0x1.0p+100f : 1.0)) * (s ? 0x1.0p+50f : 1.0f);
+        return BUILTIN_RSQRT_F32(x * (s ? 0x1.0p+100f : 1.0f)) * (s ? 0x1.0p+50f : 1.0f);
     }
 }
-

--- a/ocml/src/tanhF.cl
+++ b/ocml/src/tanhF.cl
@@ -21,9 +21,8 @@ MATH_MANGLE(tanh)(float x)
     float2 t = fdiv(fsub(e, ei), fadd(e, ei));
     float z = t.hi;
 
-    z = y > 8.6875f ? 1.0 : z;
+    z = y > 8.6875f ? 1.0f : z;
     z = y < 0x1.0p-12f ? y : z;
 
     return BUILTIN_COPYSIGN_F32(z, x);
 }
-


### PR DESCRIPTION
This improves performance because there is no need to cast to double,
compute in double precision and cast back to float.

I've noticed that ISA of `rsqrtf` function contains f64 operations:
```
        v_mac_f32_e32 v11, 0x3c23d70a, v5                          // 0000000011B8: 2C160AFF 3C23D70A 
        v_cvt_f64_f32_e32 v[9:10], v11                             // 0000000011C0: 7E12210B 
        v_cmp_gt_f32_e32 vcc, s4, v11                              // 0000000011C4: 7C881604 
        v_cndmask_b32_e32 v5, v6, v7, vcc                          // 0000000011C8: 000A0F06 
        v_mul_f64 v[9:10], v[4:5], v[9:10]                         // 0000000011CC: D2810009 00021304 
        v_cvt_f32_f64_e32 v5, v[9:10]                              // 0000000011D4: 7E0A1F09 
        v_cndmask_b32_e32 v9, 1.0, v8, vcc                         // 0000000011D8: 001210F2 
        v_rsq_f32_e32 v5, v5                                       // 0000000011DC: 7E0A4905 
        v_mac_f32_e32 v2, v9, v5                                   // 0000000011E0: 2C040B09 
```

`BUILTIN_RSQRT_F32(x * (s ? 0x1.0p+100f : 1.0))` means `BUILTIN_RSQRT_F32((float)((double)x * (s ? (double)0x1.0p+100f : 1.0)))`

After the fix:
```
        v_mac_f32_e32 v7, 0x3c23d70a, v6                           // 0000000011AC: 2C0E0CFF 3C23D70A 
        v_cmp_gt_f32_e32 vcc, s4, v7                               // 0000000011B4: 7C880E04 
        v_cndmask_b32_e32 v6, 1.0, v4, vcc                         // 0000000011B8: 000C08F2 
        v_mul_f32_e32 v6, v7, v6                                   // 0000000011BC: 0A0C0D07 
        v_rsq_f32_e32 v6, v6                                       // 0000000011C0: 7E0C4906 
        v_cndmask_b32_e32 v7, 1.0, v5, vcc                         // 0000000011C4: 000E0AF2 
        v_mac_f32_e32 v2, v7, v6                                   // 0000000011C8: 2C040D07 
```

Here is a benchmark:
https://gist.github.com/ex-rzr/beca841df21f2499957bf416a874d8af

Performance on MI25 with comparison to `__frsqrt_rn`:
```
kernel_frsqrt_rn: 0.018 ms

before:
kernel_rsqrtf: 0.094 ms

after:
kernel_rsqrtf: 0.027 ms
```

I've fixed literals in other functions too, most of them for sake of consistency.