### PR TITLE
Find LLVM avoiding the system (non-ROC) LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/dist CACHE INTERNAL "Prefix prepended to install directories")
 endif()
 
-find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR})
+find_package(LLVM REQUIRED PATHS ${LLVM_DIR} "/opt/rocm/llvm" NO_DEFAULT_PATH)
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
 include(AddLLVM)
 


### PR DESCRIPTION
Use NO_DEFAULT_PATH to avoid finding the system (non-ROC) LLVM.
Use /opt/rocm/llvm as an additional hint to be consistent with the build systems of other ROC projects (such as ROCm-OpenCL-Driver): https://github.com/RadeonOpenCompute/ROCm-OpenCL-Driver/blob/roc-2.6.0/CMakeLists.txt#L66