### PR TITLE
Remove NO_DEFAULT_PATH so llvm can be found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/dist CACHE INTERNAL "Prefix prepended to install directories")
 endif()
 
-find_package(LLVM REQUIRED PATHS ${LLVM_DIR} "/opt/rocm/llvm" NO_DEFAULT_PATH)
+find_package(LLVM REQUIRED PATHS ${LLVM_DIR} "/opt/rocm/llvm")
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
 include(AddLLVM)
 


### PR DESCRIPTION
When LLVM is not found cmake says:

```
  Add the installation prefix of "LLVM" to CMAKE_PREFIX_PATH or set
  "LLVM_DIR" to a directory containing one of the above files.
```

However, setting `CMAKE_PREFIX_PATH` does not work if we set `NO_DEFAULT_PATH`. So this is removed because using `CMAKE_PREFIX_PATH` should always work.