### PR TITLE
Set required minimum cmake version to LLVM's minimum cmake version

### DIFF
--- a/utils/prepare-builtins/CMakeLists.txt
+++ b/utils/prepare-builtins/CMakeLists.txt
@@ -5,7 +5,7 @@
 ## License. See LICENSE.TXT for details.
 ##===--------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.13.4)
 
 include(AddLLVM)
 


### PR DESCRIPTION
I think this is an oversight
